### PR TITLE
Monkey patch the "replaces" to work around fixed defect

### DIFF
--- a/configure-alertmanager-operator/0.1.36-b3c65f7/20-configure-alertmanager-operator.v0.1.36-b3c65f7.clusterserviceversion.yaml
+++ b/configure-alertmanager-operator/0.1.36-b3c65f7/20-configure-alertmanager-operator.v0.1.36-b3c65f7.clusterserviceversion.yaml
@@ -78,5 +78,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat, Inc
-  replaces: 0.1.22-aded826
+  replaces: configure-alertmanager-operator.v0.1.22-aded826
   version: 0.1.36-b3c65f7


### PR DESCRIPTION
This was incorrectly created. The defect was resolved in https://github.com/openshift/configure-alertmanager-operator/pull/23